### PR TITLE
[bugfix] CSS changes in jsCoq 0.10.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
   },
   "main": "haste",
   "dependencies": {
-    "winston": "0.6.2",
-    "connect": "1.9.2",
-    "redis-url": "0.1.0",
+    "busboy": "0.2.4",
+    "connect": "^1.9.2",
+    "mime": "^1.0.0",
     "redis": "0.8.1",
+    "redis-url": "0.1.0",
     "uglify-js": "1.3.3",
-    "busboy": "0.2.4"
+    "winston": "0.6.2"
   },
   "devDependencies": {
     "mocha": "*",

--- a/static/application.css
+++ b/static/application.css
@@ -4,6 +4,11 @@ body {
 	margin: 0px;
 }
 
+#code-wrapper,
+.CodeMirror {
+    height: 100%;
+}
+
 /* textarea */
 
 textarea {

--- a/static/index.html
+++ b/static/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 	<head>
 		<title>collacoq</title>


### PR DESCRIPTION
The spacing problem was resolved somehow by just adding the DOCTYPE header.
Weird. 😕 

I also had to make the href links absolute... because the page auto-navigates to `/collacoq/` and then it fails to find the JavaScript and CSS files. Did you have a different setup where the paths were relative? Also I had to install `mime@1.0.0` because npm was picking a version that is too new. Finally, I was not in fact able to use hastebin functionality, since again it was trying to access `/collacoq/documents` instead of `/documents`.

cc: https://github.com/ejgallego/jscoq/issues/125